### PR TITLE
Defining VPC Module

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,31 @@
+resource "aws_vpc" "eks_vpc" {
+  cidr_block = var.vpc_cidr
+  enable_dns_support = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "eks-vpc"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count = 2
+  vpc_id = aws_vpc.eks_vpc.id
+  cidr_block = cidrsubnet(var.vpc_cidr, 4, count.index)
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "eks-private-subnet-${count.index}"
+  }
+}
+
+resource "aws_subnet" "public" {
+  count = 2
+  vpc_id = aws_vpc.eks_vpc.id
+  cidr_block = cidrsubnet(var.vpc_cidr, 4, count.index + 2)
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "eks-public-subnet-${count.index}"
+  }
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.eks_vpc.id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,4 @@
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}


### PR DESCRIPTION
Defining VPC Module:

3 files:
1. main.tf:

- Defines an AWS VPC and 2 AWS Subnets
     - Subnets:
          - Private
          - Public

2. variables.tf:

- Adding variable for the VPC's CIDR block

3. outputs.tf:

- Extracts the ID's for the three resources defined in main.tf