### PR TITLE
Defined IAM Module

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_role" "eks_cluster_role" {
+  name = "eks-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "eks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "eks-cluster-role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  role       = aws_iam_role.eks_cluster_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -1,0 +1,3 @@
+output "eks_role_arn" {
+  value = aws_iam_role.eks_role.arn
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  description = "The name of the EKS cluster"
+  type        = string
+}


### PR DESCRIPTION
Defining IAM Role for EKS Cluster
This MR defines the IAM role that the EKS cluster assumes to interact with AWS services on our behalf.

The IAM role is associated with AmazonEKSClusterPolicy, an AWS-managed policy that grants the necessary permissions for EKS to manage cluster resources.
This policy allows EKS to communicate with other AWS services like EC2, Auto Scaling, and networking components but does not grant full administrative privileges.
This ensures our EKS cluster has the correct permissions while following the principle of least privilege.

