### PR TITLE
Defining eks module

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,0 +1,12 @@
+resource "aws_eks_cluster" "js-test-cluster" {
+  name     = var.cluster_name
+  role_arn = var.eks_role_arn
+
+  vpc_config {
+    subnet_ids = var.subnet_ids
+  }
+
+  tags = {
+    Name = var.cluster_name
+  }
+}

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_id" {
+  value = aws_eks_cluster.this.id
+}
+
+output "cluster_endpoint" {
+  value = aws_eks_cluster.this.endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  value = aws_eks_cluster.this.certificate_authority[0].data
+}

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -1,0 +1,19 @@
+variable "cluster_name" {
+  description = "The name of the EKS cluster"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The VPC ID where the EKS cluster will be deployed"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs where the EKS nodes will be deployed"
+  type        = list(string)
+}
+
+variable "eks_role_arn" {
+  description = "IAM Role ARN for the EKS cluster"
+  type        = string
+}


### PR DESCRIPTION
Adding EKS Module for Cluster Deployment
This MR introduces the EKS module, defining the infrastructure for deploying an Amazon EKS cluster.

Key Changes:
Created eks module, which:

Provisions an EKS cluster using aws_eks_cluster.
Accepts VPC ID, private subnets, and IAM role ARN as inputs.
Outputs cluster ID, API endpoint, and CA certificate data for further use.

main.tf: Declares the EKS resource.
variables.tf: Defines inputs required for the cluster.
outputs.tf: Exposes essential outputs.

Why This is Needed:
This module establishes the Kubernetes control plane, allowing future deployment of worker nodes and workloads within the cluster.