### PR TITLE
Removed Private Subnet

### DIFF
--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -9,7 +9,7 @@ variable "vpc_id" {
 }
 
 variable "subnet_ids" {
-  description = "List of subnet IDs where the EKS nodes will be deployed"
+  description = "List of public subnet IDs where the EKS nodes will be deployed"
   type        = list(string)
 }
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -8,17 +8,6 @@ resource "aws_vpc" "eks_vpc" {
   }
 }
 
-resource "aws_subnet" "private" {
-  count = 2
-  vpc_id = aws_vpc.eks_vpc.id
-  cidr_block = cidrsubnet(var.vpc_cidr, 4, count.index)
-  map_public_ip_on_launch = false
-
-  tags = {
-    Name = "eks-private-subnet-${count.index}"
-  }
-}
-
 resource "aws_subnet" "public" {
   count = 2
   vpc_id = aws_vpc.eks_vpc.id

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -2,10 +2,6 @@ output "vpc_id" {
   value = aws_vpc.eks_vpc.id
 }
 
-output "private_subnet_ids" {
-  value = aws_subnet.private[*].id
-}
-
 output "public_subnet_ids" {
   value = aws_subnet.public[*].id
 }


### PR DESCRIPTION
Refactoring Subnet Configuration: Removing Private Subnets
This MR updates the Terraform configuration by removing private subnets and ensuring that the EKS cluster uses only public subnets.

Why This Change?
Eliminates NAT Gateway costs (~$32/month + data transfer fees).
Simplifies networking while maintaining high availability with two public subnets.
Ensures worker nodes can still access the internet without additional routing complexity.