### PR TITLE
Adding worker node module

### DIFF
--- a/modules/worker_nodes/main.tf
+++ b/modules/worker_nodes/main.tf
@@ -1,0 +1,14 @@
+resource "aws_eks_node_group" "worker_nodes" {
+  cluster_name    = var.cluster_name
+  node_role_arn   = var.node_role_arn
+  subnet_ids      = var.subnet_ids
+  instance_types  = ["t3.medium"]
+  scaling_config {
+    desired_size = 2
+    max_size     = 3
+    min_size     = 1
+  }
+  tags = {
+    Name = "eks-worker-nodes"
+  }
+}

--- a/modules/worker_nodes/outputs.tf
+++ b/modules/worker_nodes/outputs.tf
@@ -1,0 +1,3 @@
+output "worker_node_group_name" {
+  value = aws_eks_node_group.worker_nodes.node_group_name
+}

--- a/modules/worker_nodes/variables.tf
+++ b/modules/worker_nodes/variables.tf
@@ -1,0 +1,19 @@
+variable "cluster_name" {
+  description = "The name of the EKS cluster"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The VPC ID where the worker nodes will be deployed"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of public subnet IDs for worker nodes"
+  type        = list(string)
+}
+
+variable "node_role_arn" {
+  description = "IAM Role ARN for the worker nodes"
+  type        = string
+}


### PR DESCRIPTION
Adding Worker Nodes Module for EKS Cluster:
This MR introduces the worker nodes module, enabling compute capacity for the EKS cluster.

Key Changes:
Created the worker_nodes module, which:

Provisions an EKS-managed node group.
Uses public subnets for deployment.
Assigns an IAM role for worker nodes.
Configures scaling settings (min: 1, desired: 2, max: 3).
Updated main.tf to include the worker nodes module.

Defined supporting files:

main.tf:  Defines the EKS node group.
variables.tf: Declares required inputs (cluster name, subnets, IAM role).
outputs.tf: Exposes worker node group name.

Why This is Needed:
Provides compute capacity for workloads running in the EKS cluster.
Ensures worker nodes are correctly associated with IAM roles and networking.
Deploys worker nodes into public subnets to avoid NAT Gateway costs.