### PR TITLE
Defining the Main Module for EKS Infrastructure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,26 @@
+
+module "vpc" {
+  source   = "./modules/vpc"
+  vpc_cidr = var.vpc_cidr
+}
+
+module "iam" {
+  source       = "./modules/iam"
+  cluster_name = var.cluster_name
+}
+
+module "eks" {
+  source          = "./modules/eks"
+  cluster_name    = var.cluster_name
+  vpc_id          = module.vpc.vpc_id
+  subnet_ids      = module.vpc.public_subnet_ids
+  eks_role_arn    = module.iam.eks_role_arn
+}
+
+module "worker_nodes" {
+  source       = "./modules/worker_nodes"
+  cluster_name = var.cluster_name
+  vpc_id       = module.vpc.vpc_id
+  subnet_ids   = module.vpc.public_subnet_ids
+  node_role_arn = module.iam.node_role_arn
+}


### PR DESCRIPTION
This MR sets up the main Terraform module, integrating all submodules required to provision an AWS EKS cluster.

Key Changes:
Defined the VPC module to manage networking and public subnets.
Integrated the IAM module to create roles and policies for EKS.
Added the EKS module to provision the Kubernetes control plane.
Included the Worker Nodes module to attach compute capacity to the cluster.
Configured module dependencies to ensure proper resource creation order.