### PR TITLE
Added explicit subnet references

### DIFF
--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -9,8 +9,8 @@ variable "vpc_id" {
 }
 
 variable "subnet_ids" {
-  description = "List of public subnet IDs where the EKS nodes will be deployed"
-  type        = list(string)
+  type    = list(string)
+  default = ["subnet-018a047e6e74acc93", "subnet-0cf8dd5bd2868fff8"]
 }
 
 variable "eks_role_arn" {


### PR DESCRIPTION
My first two subnets were in the same AZ. They need to be in two at least.
Created an additional subnet in another AZ and deleted one so there is only one per AZ.
Explicitly called them out in the variables file.