### PR TITLE
Removing Apply and Destroy from Dev Pipeline

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -95,7 +95,7 @@ jobs:
 
   terraform-apply:
     name: Terraform Apply (Manual Trigger)
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     needs: terraform-plan
     environment:
@@ -135,7 +135,7 @@ jobs:
 
   terraform-destroy:
     name: Terraform Destroy (Manual Trigger)
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     environment:
       name: production


### PR DESCRIPTION
Adding code to the GitHub jobs for Apply and Destroy so that they don't show up in Dev pipelines