### PR TITLE
Removing production environment reference

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -108,8 +108,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.event.inputs.apply == 'true'
     runs-on: ubuntu-22.04
     needs: terraform-plan
-    environment:
-      name: production
     timeout-minutes: 15
     
     steps:
@@ -147,8 +145,6 @@ jobs:
     name: Terraform Destroy (Manual Trigger)
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.event.inputs.apply == 'true'
     runs-on: ubuntu-22.04
-    environment:
-      name: production
     timeout-minutes: 15
     
     steps:


### PR DESCRIPTION
I had deleted the production and development environment for now but the production environment was automatically showing up again. There was a reference to it in the workflows file that I needed to remove. GitHub auto creates environments if they are specified there. I believe this works the other way around as well. We are about to find out.