### PR TITLE
Ensured destroy is dependant on plan

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -145,6 +145,7 @@ jobs:
     name: Terraform Destroy (Manual Trigger)
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.event.inputs.apply == 'true'
     runs-on: ubuntu-22.04
+    needs: terraform-plan
     timeout-minutes: 15
     
     steps:


### PR DESCRIPTION
The destroy job was running even though the plan had failed. I needed to make the destroy job dependent on the plan job by adding a needs field.