### PR TITLE
Removed needs from destroy

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -143,9 +143,8 @@ jobs:
 
   terraform-destroy:
     name: Terraform Destroy (Manual Trigger)
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.event.inputs.apply == 'true'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.event.inputs.destroy == 'true'
     runs-on: ubuntu-22.04
-    needs: terraform-plan
     timeout-minutes: 15
     
     steps:


### PR DESCRIPTION
In my last MR I added a needs field to the destroy job but that was the wrong thing to do. I just needed to update the if block instead.