### PR TITLE
Changed use_locktable back to dynamodb_table

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -4,6 +4,6 @@ terraform {
     key            = "eks-cluster/terraform.tfstate"
     region         = "us-west-2"
     encrypt        = true
-    use_lockfile = "js-lock-table"
+    dynamodb_table = "js-lock-table"
   }
 }


### PR DESCRIPTION
I don't know why the pipeline yelled at me about using use_locktable because when I used it it yelled at me again